### PR TITLE
 inventory plugin + cluster proxy plugin + managed serviceaccount plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Pycharm
-.idea
+# vscode
+.vscode/
+
+# pycharm
+.idea/

--- a/plugins/inventory/ocm_managedcluster.py
+++ b/plugins/inventory/ocm_managedcluster.py
@@ -1,0 +1,184 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+name: ocm_managedcluster
+
+plugin_type: inventory
+
+short_description: OCM managedcluster inventory
+
+author:
+- "Hao Liu (@TheRealHaoLiu) <haoli@redhat.com>"
+- "Hanqiu Zhang (@hanqiuzh) <hanzhang@redhat.com>"
+- "Nathan Weatherly (@nathanweatherly) <nweather@redhat.com>"
+
+description:
+- Fetch ocm managedclusters, and group clusters by labels.
+- Hub cluster information will be stored in the "hub" group.
+
+options:
+    plugin:
+        description: token that ensures this is a source file for the 'ocm' plugin.
+        required: True
+        type: str
+    hub_kubeconfig:
+        description:
+        - Path to an existing Kubernetes config file to connect to the hub. If not provided, and no other connection
+            options are provided, the Kubernetes client will attempt to load the default
+            configuration file from I(~/.kube/config). Can also be specified via K8S_AUTH_KUBECONFIG
+            environment variable.
+        type: str
+        required: False
+    cluster_groups:
+        description:
+        - Optional list of cluster selection settings. If no items are provided, the default kubeconfig
+            I(~/.kube/config) will be used as the hub, and will list all managedclusters on the hub.
+        type: list
+        required: False
+        suboptions:
+            name:
+                description:
+                - Required name to assign to the group of clusters. The name "hub" is reserved. Name has to be different from cluster names.
+                type: str
+                required: True
+            label_selectors:
+                description:
+                - a list of key=value strings to filter the managedclusters. Only clusters match all label selectors will be returned in the group.
+                type: list
+                required: False
+'''
+
+EXAMPLES = r'''
+plugin: ocmplus.cm.ocm_managedcluster
+hub_kubeconfig: /path/to/hub/kubeconfig
+cluster_groups:
+- name: east-region-clusters
+  label_selectors:
+  - region=us-east-1
+- name: aws-clusters
+  label_selectors:
+  - cloud=Amazon
+- name: ocp-clusters
+  label_selectors:
+  - vendor=OpenShift
+- name: add-clusters
+'''
+
+import sys
+import traceback
+IMP_ERR = {}
+try:
+    import kubernetes
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
+
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+
+
+class OCMInventoryException(Exception):
+    pass
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+    # used internally by Ansible, it should match the file name but not required
+    NAME = 'ocm_managedcluster'
+
+    def verify_file(self, path):
+        ''' return true/false if this is possibly a valid file for this plugin to consume '''
+        valid = False
+        if super().verify_file(path):
+            # base class verifies that file exists and is readable by current user
+            if path.endswith(('ocm.yaml', 'ocm.yml', 'ocmplus.yaml', 'ocmplus.yml')):
+                valid = True
+        return valid
+
+    def parse(self, inventory, loader, path, cache=True):
+        super().parse(inventory, loader, path)
+        cache_key = self._get_cache_prefix(path)
+        self._read_config_data(path)
+        self.setup(cache, cache_key)
+
+    def setup(self, cache, cache_key):
+        cluster_groups = self.get_option("cluster_groups")
+        hub_connection = self.get_option("hub_kubeconfig")
+        self.inventory.set_variable("all", "ansible_python_interpreter", sys.executable)
+        if IMP_ERR:
+            raise OCMInventoryException(IMP_ERR)
+        self.fetch_objects(cluster_groups, hub_connection)
+        # TODO: make cache to work
+        # source_data = None
+        # if cache and cache_key in self._cache:
+        #     try:
+        #         source_data = self._cache[cache_key]
+        #     except KeyError:
+        #         pass
+
+        # if not source_data:
+        #     self.fetch_objects(cluster_groups,hub_connection)
+
+    def fetch_objects(self, cluster_groups, hub_connection):
+        known_groups = []
+        client = None
+        # TODO: detect invalid hub kubeconfig
+        if hub_connection:
+            # get client from hub_connection
+            kubernetes.config.load_kube_config(config_file=hub_connection)
+            client = kubernetes.dynamic.DynamicClient(
+                kubernetes.client.api_client.ApiClient()
+            )
+        else:
+            # get client from system default
+            kubernetes.config.load_kube_config()
+            client = kubernetes.dynamic.DynamicClient(
+                kubernetes.client.api_client.ApiClient()
+            )
+
+        # add hub entry
+        hub_host_name = 'local-cluster'
+        self.inventory.add_host(hub_host_name)
+        self.inventory.add_group('hub')
+        self.inventory.add_child('hub', hub_host_name)
+        self.inventory.set_variable(
+            hub_host_name, 'cluster_name', 'local-cluster')
+        self.inventory.set_variable(
+            hub_host_name, 'kubeconfig', hub_connection)
+
+        # add groups
+        if cluster_groups:
+            for cluster_group in cluster_groups:
+                if not cluster_group.get("name"):
+                    raise OCMInventoryException(
+                        "Expecting name of cluster_group to be defined."
+                    )
+                group_name = cluster_group.get("name")
+                if group_name == "" or group_name == "hub":
+                    raise OCMInventoryException(
+                        "Expecting group_name to be not empty, and it cannot be hub."
+                    )
+
+                # create a new group
+                if group_name not in known_groups:
+                    self.inventory.add_group(group_name)
+                    known_groups.append(group_name)
+
+                # select clusters base on the given label selectors
+                # TODO: use managedclusterview instead of managedcluster to support rbac users
+                v1_managedclusters = client.resources.get(
+                    api_version="cluster.open-cluster-management.io/v1", kind="ManagedCluster")
+                label_selectors = ",".join(
+                    cluster_group.get("label_selectors", {}))
+
+                obj = v1_managedclusters.get(label_selector=label_selectors)
+                for c in obj.items:
+                    host_name = c.metadata.name
+                    if host_name in known_groups:
+                        raise OCMInventoryException(
+                            f"Expecting the host name {c.metadata.name} to be different from group name."
+                        )
+                    # add host will add an entry to the 'all' group
+                    self.inventory.add_host(host_name)
+                    self.inventory.add_child(group_name, host_name)
+                    self.inventory.set_variable(
+                        host_name, 'cluster_name', c.metadata.name)

--- a/plugins/module_utils/addon_utils.py
+++ b/plugins/module_utils/addon_utils.py
@@ -1,0 +1,115 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import traceback
+from ansible.errors import AnsibleError
+
+try:
+    from kubernetes.dynamic.exceptions import NotFoundError
+    from kubernetes.dynamic import DynamicClient
+except ImportError as e:
+    # kubernetes are always used, so if cannot be imported, will raise error directly
+    raise AnsibleError("Error importing Kubernetes: " + e) from e
+
+IMP_ERR = {}
+try:
+    import yaml
+except ImportError as e:
+    IMP_ERR['yaml'] = {'error': traceback.format_exc(),
+                       'exception': e}
+try:
+    from jinja2 import Template
+except ImportError as e:
+    IMP_ERR['jinja2'] = {'error': traceback.format_exc(),
+                         'exception': e}
+try:
+    import polling
+except ImportError as e:
+    IMP_ERR['polling'] = {'error': traceback.format_exc(), 'exception': e}
+
+ADDON_TEMPLATE = """
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: {{ addon_name }}
+  namespace: {{ managed_cluster_name }}
+spec:
+  installNamespace: {{ addon_install_namespace }}
+"""
+
+
+def get_managed_cluster_addon(hub_client: DynamicClient, addon_name: str, cluster_name: str):
+    managed_cluster_addon_api = hub_client.resources.get(
+        api_version="addon.open-cluster-management.io/v1alpha1",
+        kind="ManagedClusterAddOn",
+    )
+    managed_cluster_addon = managed_cluster_addon_api.get(
+        name=addon_name,
+        namespace=cluster_name,
+    )
+    return managed_cluster_addon
+
+
+def check_managed_cluster_addon_available(managed_cluster_addon) -> bool:
+    if managed_cluster_addon is None:
+        return False
+    for condition in managed_cluster_addon.status.conditions:
+        if condition.type == 'Available':
+            return condition.status == 'True'
+    return False
+
+
+def check_addon_available(hub_client: DynamicClient, addon_name: str, cluster_name: str):
+    addon = get_managed_cluster_addon(hub_client, addon_name, cluster_name)
+    return check_managed_cluster_addon_available(addon)
+
+
+def wait_for_addon_available(hub_client: DynamicClient, addon, timeout=60):
+    if 'polling' in IMP_ERR:
+        # if polling not available, will simply do no waiting
+        raise AnsibleError("Error importing polling: " + IMP_ERR['polling']['error'])
+    ret = polling.poll(
+        target=lambda: get_managed_cluster_addon(
+            hub_client,
+            addon_name=addon.metadata.name,
+            cluster_name=addon.metadata.namespace,
+        ),
+        check_success=check_managed_cluster_addon_available,
+        step=0.1,
+        timeout=timeout,
+    )
+
+    return ret
+
+
+def ensure_managed_cluster_addon_enabled(
+    hub_client: DynamicClient,
+    addon_name: str,
+    managed_cluster_name: str,
+    addon_install_namespace: str = "open-cluster-management-agent-addon"
+):
+    managed_cluster_addon_api = hub_client.resources.get(
+        api_version="addon.open-cluster-management.io/v1alpha1",
+        kind="ManagedClusterAddOn",
+    )
+
+    try:
+        addon = managed_cluster_addon_api.get(
+            name=addon_name,
+            namespace=managed_cluster_name,
+        )
+    except NotFoundError:
+        if 'jinja2' in IMP_ERR:
+            raise AnsibleError("Error importing jinja2: " + IMP_ERR['jinja2']['error']) from None
+        if 'yaml' in IMP_ERR:
+            raise AnsibleError("Error importing yaml: " + IMP_ERR['yaml']['error']) from None
+        new_addon_yaml = Template(ADDON_TEMPLATE).render(
+            addon_name=addon_name,
+            managed_cluster_name=managed_cluster_name,
+            addon_install_namespace=addon_install_namespace,
+        )
+        new_addon = yaml.safe_load(new_addon_yaml)
+        addon = managed_cluster_addon_api.create(new_addon)
+
+    return addon

--- a/plugins/module_utils/import_utils.py
+++ b/plugins/module_utils/import_utils.py
@@ -13,6 +13,7 @@ except ImportError as e:
     IMP_ERR['yaml'] = {'error': traceback.format_exc(),
                        'exception': e}
 try:
+    from kubernetes.dynamic import DynamicClient
     from kubernetes.dynamic.exceptions import DynamicApiError, NotFoundError
 except ImportError as e:
     IMP_ERR['k8s'] = {'error': traceback.format_exc(),
@@ -217,3 +218,17 @@ def dynamic_apply(dynamic_client, resource_dict):
     except DynamicApiError as exc:
         # TODO retry depending on error type
         raise AnsibleError(f'Failed to create object: {exc.body}')
+
+
+def get_managed_cluster(hub_client: DynamicClient, managed_cluster_name: str):
+    managed_cluster_api = hub_client.resources.get(
+        api_version="cluster.open-cluster-management.io/v1",
+        kind="ManagedCluster",
+    )
+
+    try:
+        managed_cluster = managed_cluster_api.get(name=managed_cluster_name)
+    except NotFoundError:
+        return None
+
+    return managed_cluster

--- a/plugins/modules/cluster_proxy_addon.py
+++ b/plugins/modules/cluster_proxy_addon.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+
+module: cluster_proxy_addon
+
+short_description: cluster proxy addon
+
+author:
+- "Hao Liu (@TheRealHaoLiu) <haoli@redhat.com>"
+- "Hanqiu Zhang (@hanqiuzh) <hanzhang@redhat.com>"
+- "Nathan Weatherly (@nathanweatherly) <nweather@redhat.com>"
+
+description: Install the cluster proxy addon, and get proxy url from the addon. cluster-admin permission on hub is assumed to enable the plugin.
+
+options:
+    hub_kubeconfig:
+        description: Path to the Hub cluster kubeconfig
+        type: str
+        required: True
+    wait:
+        description: Whether to wait for clusters to show up as managed clusters
+        type: bool
+        default: False
+        required: False
+    timeout:
+        description: Number of seconds to wait for the addons to show up
+        type: int
+        default: 60
+        required: False
+    managed_cluster:
+        description: Name of managed cluster to
+        type: str
+        required: True
+'''
+
+EXAMPLES = r'''
+- name: "Get proxy cluster url for example-cluster"
+  ocmplus.cm.cluster_proxy_addon:
+    hub_kubeconfig: /path/to/hub/kubeconfig
+    managed_cluster: example-cluster
+  register: cluster_proxy_url
+'''
+
+RETURN = r'''
+cluster_url:
+    description: Host url of cluster proxy
+    returned: when cluster proxy is enabled and available
+    type: str
+    sample: "https://cluster-proxy-user.apps.example.com/cluster-name"
+err:
+  description: Error message
+  returned: when there's an error
+  type: str
+  sample: null
+'''
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ocmplus.cm.plugins.module_utils.import_utils import get_managed_cluster
+from ansible_collections.ocmplus.cm.plugins.module_utils.addon_utils import (
+    ensure_managed_cluster_addon_enabled,
+    wait_for_addon_available,
+)
+
+try:
+    from kubernetes.dynamic.exceptions import NotFoundError
+    import kubernetes
+except ImportError as e:
+    # kubernetes are always used, so if cannot be imported, will raise error directly
+    raise AnsibleError("Error importing Kubernetes: " + e) from e
+
+
+def ensure_cluster_proxy_feature_enabled(hub_client: kubernetes.dynamic.DynamicClient) -> dict:
+    # get all instance of mch
+    mch_api = hub_client.resources.get(
+        api_version="operator.open-cluster-management.io/v1",
+        kind="MultiClusterHub",
+    )
+
+    mch_list = mch_api.get()
+    if len(mch_list.get('items', [])) != 1:
+        # TODO: throw error
+        return mch_list
+
+    mch = mch_list.items[0]
+    if mch.spec.enableClusterProxyAddon:
+        return mch
+
+    mch.spec.enableClusterProxyAddon = True
+    mch = mch_api.patch(
+        name=mch.metadata.name,
+        namespace=mch.metadata.namespace,
+        body=mch_list.to_dict()['items'][0],
+        content_type="application/merge-patch+json",
+    )
+
+    return mch
+
+
+def get_hub_proxy_route(hub_client: kubernetes.dynamic.DynamicClient, ocm_namespace: str):
+    route_api = hub_client.resources.get(
+        api_version="route.openshift.io/v1", kind="Route")
+    try:
+        route = route_api.get(
+            name='cluster-proxy-addon-user', namespace=ocm_namespace)
+    except NotFoundError:
+        return None
+    return route.spec.host
+
+
+def get_ocm_install_namespace(hub_client: kubernetes.dynamic.DynamicClient):
+    mch_api = hub_client.resources.get(
+        api_version="operator.open-cluster-management.io/v1",
+        kind="MultiClusterHub",
+    )
+
+    mch_list = mch_api.get()
+    if len(mch_list.get('items', [])) != 1:
+        return None
+    mch = mch_list.items[0]
+    return mch.metadata.namespace
+
+
+def execute_module(module: AnsibleModule):
+    managed_cluster_name = module.params['managed_cluster']
+
+    hub_kubeconfig = kubernetes.config.load_kube_config(
+        config_file=module.params['hub_kubeconfig'])
+    hub_client = kubernetes.dynamic.DynamicClient(
+        kubernetes.client.api_client.ApiClient(configuration=hub_kubeconfig)
+    )
+
+    timeout = module.params['timeout']
+    managed_cluster = get_managed_cluster(hub_client, managed_cluster_name)
+    if managed_cluster is None:
+        # TODO: throw error and exit
+        module.fail_json(f"managedcluster {managed_cluster_name} not found",
+                         err=f"failed to get managedcluster {managed_cluster_name} not found")
+        # TODO: there might be other exit condition
+
+    ensure_cluster_proxy_feature_enabled(hub_client)
+    cluster_proxy_addon = ensure_managed_cluster_addon_enabled(
+        hub_client, "cluster-proxy", managed_cluster_name, "open-cluster-management-agent-addon")
+
+    wait = module.params['wait']
+    if wait:
+        wait_for_addon_available(hub_client, cluster_proxy_addon, timeout)
+
+    ocm_namespace = get_ocm_install_namespace(hub_client)
+    if ocm_namespace is None:
+        module.fail_json("failed to detect ocm namespace",
+                         err="failed to detect ocm namespace")
+
+    hub_proxy_url = get_hub_proxy_route(hub_client, ocm_namespace)
+    if hub_proxy_url == "" or hub_proxy_url is None:
+        module.fail_json("failed to get hub proxy url",
+                         err="failed to get hub proxy url")
+
+    cluster_url = f"https://{hub_proxy_url}/{managed_cluster_name}"
+    module.exit_json(cluster_url=cluster_url)
+
+
+def main():
+    argument_spec = dict(
+        hub_kubeconfig=dict(type='str', required=True),
+        managed_cluster=dict(type='str', required=True),
+        wait=dict(type='bool', required=False, default=False),
+        timeout=dict(type='int', required=False, default=60)
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/managed_serviceaccount_addon.py
+++ b/plugins/modules/managed_serviceaccount_addon.py
@@ -1,0 +1,376 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+
+module: managed_serviceaccount_addon
+
+short_description: cluster proxy addon
+
+author:
+- "Hao Liu (@TheRealHaoLiu) <haoli@redhat.com>"
+- "Hanqiu Zhang (@hanqiuzh) <hanzhang@redhat.com>"
+- "Nathan Weatherly (@nathanweatherly) <nweather@redhat.com>"
+
+description:
+- Use the managed-serviceaccount addon to setup a serviceaccount on a managedcluster with default admin permission,
+    and return the serviceaccount token.
+
+options:
+    hub_kubeconfig:
+        description: Path to the Hub cluster kubeconfig.
+        type: str
+        required: True
+    wait:
+        description: Whether to wait for clusters to show up as managed clusters.
+        type: bool
+        default: False
+        required: False
+    timeout:
+        description: Number of seconds to wait for the addons to show up.
+        type: int
+        default: 60
+        required: False
+    managed_cluster:
+        description: Name of managed cluster to create serviceaccount.
+        type: str
+        required: True
+'''
+
+EXAMPLES = r'''
+- name: "Get serviceaccount token"
+  ocmplus.cm.managed_serviceaccount_addon:
+    hub_kubeconfig: /path/to/hub/kubeconfig
+    managed_cluster: example-cluster
+    wait: True
+    timeout: 60
+  register: token
+'''
+
+RETURN = r'''
+token:
+    description: token of the specific serviceaccount
+    returned: when cluster proxy is enabled and available
+    type: str
+    sample: "ey..."
+err:
+  description: Error message
+  returned: when there's an error
+  type: str
+  sample: null
+'''
+
+import base64
+import traceback
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ocmplus.cm.plugins.module_utils.import_utils import get_managed_cluster
+from ansible_collections.ocmplus.cm.plugins.module_utils.addon_utils import (
+    check_addon_available,
+    get_managed_cluster_addon,
+    wait_for_addon_available
+)
+
+IMP_ERR = {}
+try:
+    import yaml
+except ImportError as e:
+    IMP_ERR['yaml'] = {'error': traceback.format_exc(),
+                       'exception': e}
+try:
+    from jinja2 import Template
+except ImportError as e:
+    IMP_ERR['jinja2'] = {'error': traceback.format_exc(),
+                         'exception': e}
+try:
+    import polling
+except ImportError as e:
+    IMP_ERR['polling'] = {'error': traceback.format_exc(), 'exception': e}
+
+try:
+    import kubernetes
+    from kubernetes.dynamic.exceptions import NotFoundError
+except ImportError as e:
+    # kubernetes are always used, so if cannot be imported, will raise error directly
+    raise AnsibleError("Error importing Kubernetes: " + e) from e
+
+SERVICE_ACCOUNT_MANIFEST_WORK_TEMPLATE = """
+apiVersion: work.open-cluster-management.io/v1
+kind: ManifestWork
+metadata:
+  name: {{ service_account_name }}.serviceaccount
+  namespace: {{ cluster_name }}
+spec:
+  workload:
+    manifests:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: {{ service_account_name }}
+        namespace: {{ service_account_namespace }}
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{ service_account_name }}
+        namespace: {{ service_account_namespace }}
+        annotations:
+          kubernetes.io/service-account.name: {{ service_account_name }}
+      type: kubernetes.io/service-account-token
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: {{ service_account_name }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+        - kind: ServiceAccount
+          name: {{ service_account_name }}
+          namespace: {{ service_account_namespace }}
+"""
+
+MANAGED_SERVICE_ACCOUNT_TEMPLATE = """
+apiVersion: authentication.open-cluster-management.io/v1alpha1
+kind: ManagedServiceAccount
+metadata:
+  name: cluster-proxy
+  namespace: {{ cluster_name }}
+spec:
+  projected:
+    type: None
+  rotation: {}
+"""
+
+MANAGED_SERVICE_ACCOUNT_CLUSTER_ROLE_BINDING_TEMPLATE = """
+apiVersion: work.open-cluster-management.io/v1
+kind: ManifestWork
+metadata:
+  name: {{ managed_service_account_name }}.cluster-role-binding
+  namespace: {{ cluster_name }}
+spec:
+  workload:
+    manifests:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: {{ managed_service_account_name }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+        - kind: ServiceAccount
+          name: {{ managed_service_account_name }}
+          namespace: {{ managed_service_account_namespace }}
+"""
+
+
+def ensure_managed_service_account_feature_enabled(hub_client: kubernetes.dynamic.DynamicClient):
+    # NOTE: managed service account is not a supported feature in ACM yet and it's currently a upstream proposed feature
+    #       for more information see https://github.com/open-cluster-management-io/enhancements/pull/24
+    # TODO: the code currently only check if managed-serviceaccount feature is enabled
+    #  it does not enable the feature yet this code will need to be updated when the feature become officially part of
+    #  ACM
+
+    cluster_management_addon_api = hub_client.resources.get(
+        api_version="addon.open-cluster-management.io/v1alpha1",
+        kind="ClusterManagementAddOn",
+    )
+
+    return cluster_management_addon_api.get(name='managed-serviceaccount')
+
+
+def get_hub_serviceaccount_secret(hub_client: kubernetes.dynamic.DynamicClient, managed_service_account):
+    secret_api = hub_client.resources.get(
+        api_version="v1",
+        kind="Secret",
+    )
+    secret_name = managed_service_account.metadata.name
+    if managed_service_account.tokenSecretRef is not None and managed_service_account.tokenSecretRef.name != "":
+        secret_name = managed_service_account.tokenSecretRef.name
+
+    secret = None
+    try:
+        secret = secret_api.get(
+            name=secret_name,
+            namespace=managed_service_account.metadata.namespace
+        )
+    except NotFoundError:
+        return None
+    return secret
+
+
+def wait_for_serviceaccount_secret(hub_client: kubernetes.dynamic.DynamicClient, managed_service_account, timeout=60):
+    if 'polling' in IMP_ERR:
+        raise AnsibleError("Error importing polling: " + IMP_ERR['polling']['error']) from None
+
+    managed_service_account_api = hub_client.resources.get(
+        api_version="authentication.open-cluster-management.io/v1alpha1",
+        kind="ManagedServiceAccount",
+    )
+
+    def check_success(response) -> bool:
+        if response is None:
+            return False
+        for condition in response['status']['conditions']:
+            if condition['type'] == 'SecretCreated':
+                return condition['status'] == 'True'
+        return False
+
+    is_available = polling.poll(
+        target=lambda: managed_service_account_api.get(
+            name=managed_service_account.metadata.name,
+            namespace=managed_service_account.metadata.namespace
+        ),
+        check_success=check_success,
+        step=0.1,
+        timeout=timeout,
+    )
+
+    return is_available
+
+
+def ensure_managed_service_account(hub_client: kubernetes.dynamic.DynamicClient, managed_service_account_addon):
+    if 'jinja2' in IMP_ERR:
+        raise AnsibleError("Error importing jinja2: " + IMP_ERR['jinja2']['error']) from None
+    if 'yaml' in IMP_ERR:
+        raise AnsibleError("Error importing yaml: " + IMP_ERR['yaml']['error']) from None
+    managed_cluster_name = managed_service_account_addon.metadata.namespace
+    managed_cluster_namespace = managed_service_account_addon.metadata.namespace
+
+    managed_service_account_api = hub_client.resources.get(
+        api_version="authentication.open-cluster-management.io/v1alpha1",
+        kind="ManagedServiceAccount",
+    )
+
+    try:
+        managed_service_account = managed_service_account_api.get(
+            name='cluster-proxy',
+            namespace=managed_cluster_namespace,
+        )
+    except NotFoundError:
+        new_managed_service_account_raw = Template(MANAGED_SERVICE_ACCOUNT_TEMPLATE).render(
+            cluster_name=managed_cluster_name,
+        )
+        managed_service_account_yaml = yaml.safe_load(
+            new_managed_service_account_raw)
+        managed_service_account = managed_service_account_api.create(
+            managed_service_account_yaml)
+
+    return managed_service_account
+
+
+def ensure_managed_service_account_rbac(hub_client, managed_service_account, managed_service_account_addon):
+    if 'jinja2' in IMP_ERR:
+        raise AnsibleError("Error importing jinja2: " + IMP_ERR['jinja2']['error']) from None
+    if 'yaml' in IMP_ERR:
+        raise AnsibleError("Error importing yaml: " + IMP_ERR['yaml']['error']) from None
+    managed_cluster_name = managed_service_account_addon.metadata.namespace
+    managed_service_account_name = managed_service_account.metadata.name
+    managed_service_account_namespace = managed_service_account_addon.spec.installNamespace
+
+    manifest_work_api = hub_client.resources.get(
+        api_version="work.open-cluster-management.io/v1",
+        kind="ManifestWork",
+    )
+
+    new_manifest_work_raw = Template(MANAGED_SERVICE_ACCOUNT_CLUSTER_ROLE_BINDING_TEMPLATE).render(
+        cluster_name=managed_cluster_name,
+        managed_service_account_name=managed_service_account_name,
+        managed_service_account_namespace=managed_service_account_namespace,
+    )
+
+    new_manifest_work = yaml.safe_load(new_manifest_work_raw)
+
+    try:
+        manifest_work = manifest_work_api.get(
+            name=new_manifest_work['metadata']['name'],
+            namespace=new_manifest_work['metadata']['namespace'],
+        )
+        # TODO: validate existing service_account_manifest_work and verify that it is what we expected update if not
+    except NotFoundError:
+        manifest_work = manifest_work_api.create(new_manifest_work)
+        # TODO: we may need to wait for the manifest work to be applied
+
+    return manifest_work
+
+
+def execute_module(module: AnsibleModule):
+    managed_cluster_name = module.params['managed_cluster']
+
+    hub_kubeconfig = kubernetes.config.load_kube_config(
+        config_file=module.params['hub_kubeconfig'])
+    hub_client = kubernetes.dynamic.DynamicClient(
+        kubernetes.client.api_client.ApiClient(configuration=hub_kubeconfig)
+    )
+
+    managed_cluster = get_managed_cluster(hub_client, managed_cluster_name)
+    if managed_cluster is None:
+        # TODO: throw error and exit
+        module.fail_json(
+            err=f'failed to get managedcluster {managed_cluster_name}')
+        # TODO: there might be other exit condition
+
+    ensure_managed_service_account_feature_enabled(hub_client)
+
+    managed_service_account_addon = get_managed_cluster_addon(
+        hub_client, "managed-serviceaccount", managed_cluster_name)
+    wait = module.params['wait']
+    timeout = module.params['timeout']
+    if timeout is None or timeout <= 0:
+        timeout = 60
+    if wait:
+        wait_for_addon_available(
+            hub_client, managed_service_account_addon, timeout)
+
+    if not check_addon_available(hub_client, "managed-serviceaccount", managed_cluster_name):
+        module.fail_json(
+            err=f'failed to check addon: addon managed-serviceaccount of {managed_cluster_name} is not available')
+
+    managed_service_account = ensure_managed_service_account(
+        hub_client, managed_service_account_addon)
+    ensure_managed_service_account_rbac(
+        hub_client, managed_service_account, managed_service_account_addon)
+
+    # wait service account secret
+    if wait:
+        wait_for_serviceaccount_secret(
+            hub_client, managed_service_account, timeout)
+    managed_service_account = ensure_managed_service_account(
+        hub_client, managed_service_account_addon)
+
+    # grab secret
+    secret = get_hub_serviceaccount_secret(hub_client, managed_service_account)
+    if secret is None:
+        module.fail_json(
+            err=f'failed to get secret: secret of managedserviceaccount {managed_service_account.metadata.name} of cluster {managed_cluster_name} is not found')
+
+    # get token
+    token_bytes = base64.b64decode(secret.data.token)
+    token = token_bytes.decode('ascii')
+    module.exit_json(token=token)
+
+
+def main():
+    argument_spec = dict(
+        hub_kubeconfig=dict(type='str', required=True),
+        managed_cluster=dict(type='str', required=True),
+        wait=dict(type='bool', required=False, default=False),
+        timeout=dict(type='int', required=False, default=60),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -20,3 +20,41 @@ plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not suppor
 plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
 plugins/module_utils/import_utils.py pylint:ansible-bad-module-import # TODO issue #33
 plugins/modules/import_eks.py validate-modules!skip # TODO 
+plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
+plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
+plugins/module_utils/addon_utils.py import-3.5 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.6 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.7 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.8 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.9 # TODO issue #32
+plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported
+plugins/module_utils/addon_utils.py compile-2.7!skip # Python 2.x is not supported
+plugins/module_utils/addon_utils.py compile-3.5!skip # Python 3.5 is not supported
+plugins/module_utils/addon_utils.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/cluster_proxy_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py import-3.5 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.6 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.7 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.8 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.9 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/cluster_proxy_addon.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/cluster_proxy_addon.py validate-modules!skip # TODO 
+plugins/modules/managed_serviceaccount_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py import-3.5 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.6 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.7 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.8 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.9 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/managed_serviceaccount_addon.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/managed_serviceaccount_addon.py validate-modules!skip # TODO
+plugins/inventory/ocm_managedcluster.py compile-2.6!skip # Python 2.x is not supported
+plugins/inventory/ocm_managedcluster.py compile-2.7!skip # Python 2.x is not supported
+plugins/inventory/ocm_managedcluster.py compile-3.5!skip # Python 3.5 is not supported

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -20,3 +20,43 @@ plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not suppor
 plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
 plugins/module_utils/import_utils.py pylint:ansible-bad-module-import # TODO issue #33
 plugins/modules/import_eks.py validate-modules!skip # TODO 
+plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
+plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
+plugins/module_utils/addon_utils.py import-3.5 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.6 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.7 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.8 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.9 # TODO issue #32
+plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported
+plugins/module_utils/addon_utils.py compile-2.7!skip # Python 2.x is not supported
+plugins/module_utils/addon_utils.py compile-3.5!skip # Python 3.5 is not supported
+plugins/module_utils/addon_utils.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/cluster_proxy_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py import-3.5 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.6 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.7 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.8 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.9 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/cluster_proxy_addon.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/cluster_proxy_addon.py validate-modules!skip # TODO 
+plugins/modules/managed_serviceaccount_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py import-3.5 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.6 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.7 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.8 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.9 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/managed_serviceaccount_addon.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/managed_serviceaccount_addon.py validate-modules!skip # TODO
+plugins/inventory/ocm_managedcluster.py compile-2.6!skip # Python 2.x is not supported
+plugins/inventory/ocm_managedcluster.py compile-2.7!skip # Python 2.x is not supported
+plugins/inventory/ocm_managedcluster.py compile-3.5!skip # Python 3.5 is not supported
+plugins/inventory/ocm_managedcluster.py import-2.7 # Python 2.x is not supported
+plugins/inventory/ocm_managedcluster.py import-3.5 # TODO issue #32

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -22,3 +22,41 @@ plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not suppor
 plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
 plugins/module_utils/import_utils.py pylint:ansible-bad-module-import # TODO issue #33
 plugins/modules/import_eks.py validate-modules!skip # TODO 
+plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
+plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
+plugins/module_utils/addon_utils.py import-3.5 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.6 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.7 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.8 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.9 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.10 # TODO issue #32
+plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported
+plugins/module_utils/addon_utils.py compile-2.7!skip # Python 2.x is not supported
+plugins/module_utils/addon_utils.py compile-3.5!skip # Python 3.5 is not supported
+plugins/module_utils/addon_utils.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/cluster_proxy_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py import-3.5 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.6 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.7 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.8 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.9 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.10 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/cluster_proxy_addon.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/cluster_proxy_addon.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/cluster_proxy_addon.py validate-modules!skip # TODO 
+plugins/modules/managed_serviceaccount_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py import-3.5 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.6 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.7 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.8 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.9 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.10 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/managed_serviceaccount_addon.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/managed_serviceaccount_addon.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/managed_serviceaccount_addon.py validate-modules!skip # TODO


### PR DESCRIPTION
updates:
- created inventory plugin to help user generate groups based on label selectors
- created cluster proxy plugin to enable proxy and generate a url on hub
- created managed serviceaccount plugin to use the managed serviceaccount addon and get token

With the changes, we can have a inventory like the following, which will have a group of kind clusters:
```
# ocm.yml
plugin: ocmplus.cm.ocm_managedcluster
hub_kubeconfig: /path/to/hub/kubeconfig
cluster_groups:
- name: kind-clusters
  label_selectors:
  - name=kind
```

We will also have a playbook which will generate a serviceaccount token, and use the token to create a namespace on managedcluster:
```
# playbook.yml
- name: create a namespace named ansible-test
  hosts: kind-clusters
  connection: local
  tasks:
  - name: "Get proxy cluster url for example-cluster"
    ocmplus.cm.cluster_proxy_addon:
      hub_kubeconfig: "{{hostvars['local-cluster'].kubeconfig}}"
      managed_cluster: "{{hostvars[inventory_hostname].cluster_name}}"
    register: cluster_proxy_url

  - name: debug
    debug:
      msg: "{{cluster_proxy_url.cluster_url}}"

  - name: "Get token for example-cluster"
    ocmplus.cm.managed_serviceaccount_addon:
      hub_kubeconfig: "{{hostvars['local-cluster'].kubeconfig}}"
      managed_cluster: "{{hostvars[inventory_hostname].cluster_name}}"
      wait: True
      timeout: 60
    register: token

  - name: debug
    debug:
      msg: "{{token.token}}"

  - name: create ns
    kubernetes.core.k8s:
      state: present
      host: "{{cluster_proxy_url.cluster_url}}"
      ca_cert:  /path/to/hub/ingress/ca.crt
      api_key: "{{token.token}}"
      definition:
        apiVersion: v1
        kind: Namespace
        metadata:
          name: ansible-test-ns
```

When running the command `ansible-playbook -i ocm.yml playbook.yml`, a namespace `ansible-test-ns` will be created on the kind cluster we are targeting.