### PR TITLE
updating links and references to the stolostron github org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ contribution. See the [DCO](DCO) file for details.
 
 Anyone may comment on issues and submit reviews for pull requests. However, in
 order to be assigned an issue or pull request, you must be a member of the
-[open-cluster-management](https://github.com/open-cluster-management) GitHub organization.
+[stolostron](https://github.com/stolostron) GitHub organization.
 
 Repo maintainers can assign you an issue or pull request by leaving a
 `/assign <your Github ID>` comment on the issue or pull request.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,7 +20,7 @@ authors:
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection
-description: An Ansible Collection for use with the open-cluster-management and ocmplus projects, as well as the Red Hat Advanced Cluster Management for Kubernetes and MultiCluster Engine Products.  
+description: An Ansible Collection for use with the stolostron and ocmplus projects, as well as the Red Hat Advanced Cluster Management for Kubernetes and MultiCluster Engine Products.  
 
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
@@ -50,16 +50,16 @@ tags: [
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: https://github.com/open-cluster-management/ocmplus.cm
+repository: https://github.com/stolostron/ocmplus.cm
 
 # The URL to any online docs
-documentation: https://github.com/open-cluster-management/ocmplus.cm
+documentation: https://github.com/stolostron/ocmplus.cm
 
 # The URL to the homepage of the collection/project
-homepage: https://github.com/open-cluster-management
+homepage: https://github.com/stolostron
 
 # The URL to the collection issue tracker
-issues: https://github.com/open-cluster-management/ocmplus.cm/issues
+issues: https://github.com/stolostron/ocmplus.cm/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This


### PR DESCRIPTION
Signed-off-by: Nathan Weatherly <nweather@redhat.com>

Rename started Jan 4 2022 to rename `open-cluster-management` org to `stolostron` (which, coincidentally, is much more fun to type. Try it. _stolostron_. Such fun.)

Keep in mind, this rename does not affect APIs or code values in any way-- it just affects the name of the GitHub organization. 