### PR TITLE
use env var for hub_kubeconfig

### DIFF
--- a/plugins/modules/cluster_proxy_addon.py
+++ b/plugins/modules/cluster_proxy_addon.py
@@ -19,7 +19,7 @@ description: Install the cluster proxy addon, and get proxy url from the addon. 
 
 options:
     hub_kubeconfig:
-        description: Path to the Hub cluster kubeconfig
+        description: Path to the Hub cluster kubeconfig. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.
         type: str
         required: True
     wait:
@@ -60,7 +60,7 @@ err:
 '''
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.ocmplus.cm.plugins.module_utils.import_utils import get_managed_cluster
 from ansible_collections.ocmplus.cm.plugins.module_utils.addon_utils import (
     ensure_managed_cluster_addon_enabled,
@@ -167,7 +167,7 @@ def execute_module(module: AnsibleModule):
 
 def main():
     argument_spec = dict(
-        hub_kubeconfig=dict(type='str', required=True),
+        hub_kubeconfig=dict(type='str', required=True, fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
         managed_cluster=dict(type='str', required=True),
         wait=dict(type='bool', required=False, default=False),
         timeout=dict(type='int', required=False, default=60)

--- a/plugins/modules/import_eks.py
+++ b/plugins/modules/import_eks.py
@@ -25,7 +25,7 @@ options:
     type: str
     required: yes
   hub_kubeconfig:
-    description: Path to the ACM Hub cluster kubeconfig
+    description: Path to the ACM Hub cluster kubeconfig. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.
     type: str
     required: yes
   wait:
@@ -195,7 +195,7 @@ except ImportError as e:
     IMP_ERR['k8s'] = {'error': traceback.format_exc(),
                       'exception': e}
 from ansible.errors import AnsibleError
-from ansible.module_utils.basic import missing_required_lib, to_native
+from ansible.module_utils.basic import missing_required_lib, to_native, env_fallback
 from ansible_collections.ocmplus.cm.plugins.module_utils import import_utils
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -304,7 +304,7 @@ def main():
     # define available arguments/parameters a user can pass to the module
     argument_spec = dict(
         eks_cluster_name=dict(type='str', required=True),
-        hub_kubeconfig=dict(type='str', required=True),
+        hub_kubeconfig=dict(type='str', required=True, fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
         wait=dict(type='bool', required=False, default=False),
         timeout=dict(type='int', required=False, default=60),
         addons=dict(

--- a/plugins/modules/managed_serviceaccount_addon.py
+++ b/plugins/modules/managed_serviceaccount_addon.py
@@ -21,7 +21,7 @@ description:
 
 options:
     hub_kubeconfig:
-        description: Path to the Hub cluster kubeconfig.
+        description: Path to the Hub cluster kubeconfig. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.
         type: str
         required: True
     wait:
@@ -67,7 +67,7 @@ import base64
 import traceback
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.ocmplus.cm.plugins.module_utils.import_utils import get_managed_cluster
 from ansible_collections.ocmplus.cm.plugins.module_utils.addon_utils import (
     check_addon_available,
@@ -358,7 +358,7 @@ def execute_module(module: AnsibleModule):
 
 def main():
     argument_spec = dict(
-        hub_kubeconfig=dict(type='str', required=True),
+        hub_kubeconfig=dict(type='str', required=True, fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
         managed_cluster=dict(type='str', required=True),
         wait=dict(type='bool', required=False, default=False),
         timeout=dict(type='int', required=False, default=60),


### PR DESCRIPTION
When accessing kubeconfig, Ansible Tower credential can save secret as a file with a generated filename, however, I didn't find a good way to pass the filename as a variable to the inventory plugin, so I think we can pass it as a env var.

Currently using `K8S_AUTH_KUBECONFIG` for all hub_kubeconfig, which is the default kubeconfig env var for k8s plugin.

Updates:
- added `K8S_AUTH_KUBECONFIG` support for all plugins.

Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>