### PR TITLE
fix ansible.errors error

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -47,7 +47,8 @@ tags: [
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+  amazon.aws: '>=3.0.0'
 
 # The URL of the originating SCM repository
 repository: https://github.com/stolostron/ocmplus.cm

--- a/plugins/inventory/ocm_managedcluster.py
+++ b/plugins/inventory/ocm_managedcluster.py
@@ -90,7 +90,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         valid = False
         if super().verify_file(path):
             # base class verifies that file exists and is readable by current user
-            if path.endswith(('ocm.yaml', 'ocm.yml', 'ocmplus.yaml', 'ocmplus.yml')):
+            if path.endswith(('.yaml', '.yml')):
                 valid = True
         return valid
 
@@ -123,16 +123,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if IMP_ERR:
             raise OCMInventoryException(IMP_ERR)
         self.fetch_objects(cluster_groups, hub_connection)
-        # TODO: make cache to work
-        # source_data = None
-        # if cache and cache_key in self._cache:
-        #     try:
-        #         source_data = self._cache[cache_key]
-        #     except KeyError:
-        #         pass
-
-        # if not source_data:
-        #     self.fetch_objects(cluster_groups,hub_connection)
 
     def fetch_objects(self, cluster_groups, hub_connection):
         known_groups = []

--- a/plugins/module_utils/addon_utils.py
+++ b/plugins/module_utils/addon_utils.py
@@ -3,16 +3,16 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import traceback
-from ansible.errors import AnsibleError
 
-try:
-    from kubernetes.dynamic.exceptions import NotFoundError
-    from kubernetes.dynamic import DynamicClient
-except ImportError as e:
-    # kubernetes are always used, so if cannot be imported, will raise error directly
-    raise AnsibleError("Error importing Kubernetes: " + e) from e
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 IMP_ERR = {}
+try:
+    from kubernetes.dynamic.exceptions import NotFoundError, DynamicApiError
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
+
 try:
     import yaml
 except ImportError as e:
@@ -39,7 +39,7 @@ spec:
 """
 
 
-def get_managed_cluster_addon(hub_client: DynamicClient, addon_name: str, cluster_name: str):
+def get_managed_cluster_addon(hub_client, addon_name: str, cluster_name: str):
     managed_cluster_addon_api = hub_client.resources.get(
         api_version="addon.open-cluster-management.io/v1alpha1",
         kind="ManagedClusterAddOn",
@@ -60,15 +60,15 @@ def check_managed_cluster_addon_available(managed_cluster_addon) -> bool:
     return False
 
 
-def check_addon_available(hub_client: DynamicClient, addon_name: str, cluster_name: str):
+def check_addon_available(hub_client, addon_name: str, cluster_name: str):
     addon = get_managed_cluster_addon(hub_client, addon_name, cluster_name)
     return check_managed_cluster_addon_available(addon)
 
 
-def wait_for_addon_available(hub_client: DynamicClient, addon, timeout=60):
+def wait_for_addon_available(module: AnsibleModule, hub_client, addon, timeout=60):
     if 'polling' in IMP_ERR:
         # if polling not available, will simply do no waiting
-        raise AnsibleError("Error importing polling: " + IMP_ERR['polling']['error'])
+        module.fail_json(msg=missing_required_lib('polling'), exception=IMP_ERR['polling']['exception'])
     ret = polling.poll(
         target=lambda: get_managed_cluster_addon(
             hub_client,
@@ -84,16 +84,20 @@ def wait_for_addon_available(hub_client: DynamicClient, addon, timeout=60):
 
 
 def ensure_managed_cluster_addon_enabled(
-    hub_client: DynamicClient,
+    module: AnsibleModule,
+    hub_client,
     addon_name: str,
     managed_cluster_name: str,
     addon_install_namespace: str = "open-cluster-management-agent-addon"
 ):
+    if 'k8s' in IMP_ERR:
+        module.fail_json(msg=missing_required_lib('kubernetes'), exception=IMP_ERR['k8s']['exception'])
+
     managed_cluster_addon_api = hub_client.resources.get(
         api_version="addon.open-cluster-management.io/v1alpha1",
         kind="ManagedClusterAddOn",
     )
-
+    addon = None
     try:
         addon = managed_cluster_addon_api.get(
             name=addon_name,
@@ -101,15 +105,18 @@ def ensure_managed_cluster_addon_enabled(
         )
     except NotFoundError:
         if 'jinja2' in IMP_ERR:
-            raise AnsibleError("Error importing jinja2: " + IMP_ERR['jinja2']['error']) from None
+            module.fail_json(msg=missing_required_lib('jinja2'), exception=IMP_ERR['jinja2']['exception'])
         if 'yaml' in IMP_ERR:
-            raise AnsibleError("Error importing yaml: " + IMP_ERR['yaml']['error']) from None
+            module.fail_json(msg=missing_required_lib('yaml'), exception=IMP_ERR['yaml']['exception'])
         new_addon_yaml = Template(ADDON_TEMPLATE).render(
             addon_name=addon_name,
             managed_cluster_name=managed_cluster_name,
             addon_install_namespace=addon_install_namespace,
         )
         new_addon = yaml.safe_load(new_addon_yaml)
-        addon = managed_cluster_addon_api.create(new_addon)
+        try:
+            addon = managed_cluster_addon_api.create(new_addon)
+        except DynamicApiError as e:
+            module.fail_json(msg=f'failed to create managedclusteraddon {addon_name}', exception=e)
 
     return addon

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ botocore>=1.18.0
 boto3>=1.15.0
 awscli>=1.22.6
 kubernetes>=12.0.0
-backoff>=1.11.1
 polling>=0.3.2
 pyyaml>=5.0

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,2 @@
+modules:
+    python_requires: '>=3.6'

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,60 +1,37 @@
 plugins/modules/import_eks.py import-2.6 # Python 2.x is not supported
 plugins/modules/import_eks.py import-2.7 # Python 2.x is not supported
-plugins/modules/import_eks.py import-3.5 # TODO issue #32
-plugins/modules/import_eks.py import-3.6 # TODO issue #32
-plugins/modules/import_eks.py import-3.7 # TODO issue #32
-plugins/modules/import_eks.py import-3.8 # TODO issue #32
-plugins/modules/import_eks.py import-3.9 # TODO issue #32
+plugins/modules/import_eks.py import-3.5 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.6 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.7 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.8 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.9 # amazon.aws collection is required
 plugins/modules/import_eks.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/import_eks.py compile-2.7!skip # Python 2.x is not supported
-plugins/modules/import_eks.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/import_eks.py validate-modules!skip # amazon.aws collection is required
 plugins/module_utils/import_utils.py import-2.6 # Python 2.x is not supported
 plugins/module_utils/import_utils.py import-2.7 # Python 2.x is not supported
-plugins/module_utils/import_utils.py import-3.5 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.6 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.7 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.8 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.9 # TODO issue #32
+plugins/module_utils/import_utils.py import-3.5 # Python 3.5 is not supported
 plugins/module_utils/import_utils.py compile-2.6!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
-plugins/module_utils/import_utils.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/import_eks.py validate-modules!skip # TODO 
 plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
 plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
-plugins/module_utils/addon_utils.py import-3.5 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.6 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.7 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.8 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.9 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.5 # Python 3.5 is not supported
 plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported
 plugins/module_utils/addon_utils.py compile-2.7!skip # Python 2.x is not supported
 plugins/module_utils/addon_utils.py compile-3.5!skip # Python 3.5 is not supported
-plugins/module_utils/addon_utils.py pylint:ansible-bad-module-import # TODO issue #33
 plugins/modules/cluster_proxy_addon.py import-2.6 # Python 2.x is not supported
 plugins/modules/cluster_proxy_addon.py import-2.7 # Python 2.x is not supported
-plugins/modules/cluster_proxy_addon.py import-3.5 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.6 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.7 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.8 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.9 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.5 # Python 3.5 is not supported
 plugins/modules/cluster_proxy_addon.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy_addon.py compile-2.7!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy_addon.py compile-3.5!skip # Python 3.5 is not supported
-plugins/modules/cluster_proxy_addon.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/cluster_proxy_addon.py validate-modules!skip # TODO 
 plugins/modules/managed_serviceaccount_addon.py import-2.6 # Python 2.x is not supported
 plugins/modules/managed_serviceaccount_addon.py import-2.7 # Python 2.x is not supported
-plugins/modules/managed_serviceaccount_addon.py import-3.5 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.6 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.7 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.8 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.9 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.5 # Python 3.5 is not supported
 plugins/modules/managed_serviceaccount_addon.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/managed_serviceaccount_addon.py compile-2.7!skip # Python 2.x is not supported
 plugins/modules/managed_serviceaccount_addon.py compile-3.5!skip # Python 3.5 is not supported
-plugins/modules/managed_serviceaccount_addon.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/managed_serviceaccount_addon.py validate-modules!skip # TODO
 plugins/inventory/ocm_managedcluster.py compile-2.6!skip # Python 2.x is not supported
 plugins/inventory/ocm_managedcluster.py compile-2.7!skip # Python 2.x is not supported
 plugins/inventory/ocm_managedcluster.py compile-3.5!skip # Python 3.5 is not supported

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,62 +1,39 @@
 plugins/modules/import_eks.py import-2.6 # Python 2.x is not supported
 plugins/modules/import_eks.py import-2.7 # Python 2.x is not supported
-plugins/modules/import_eks.py import-3.5 # TODO issue #32
-plugins/modules/import_eks.py import-3.6 # TODO issue #32
-plugins/modules/import_eks.py import-3.7 # TODO issue #32
-plugins/modules/import_eks.py import-3.8 # TODO issue #32
-plugins/modules/import_eks.py import-3.9 # TODO issue #32
+plugins/modules/import_eks.py import-3.5 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.6 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.7 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.8 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.9 # amazon.aws collection is required
 plugins/modules/import_eks.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/import_eks.py compile-2.7!skip # Python 2.x is not supported
-plugins/modules/import_eks.py pylint:ansible-bad-module-import # TODO issue #33
+plugins/modules/import_eks.py validate-modules!skip # amazon.aws collection is required
 plugins/module_utils/import_utils.py import-2.6 # Python 2.x is not supported
 plugins/module_utils/import_utils.py import-2.7 # Python 2.x is not supported
-plugins/module_utils/import_utils.py import-3.5 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.6 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.7 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.8 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.9 # TODO issue #32
+plugins/module_utils/import_utils.py import-3.5 # Python 3.5 is not supported
 plugins/module_utils/import_utils.py compile-2.6!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
-plugins/module_utils/import_utils.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/import_eks.py validate-modules!skip # TODO 
 plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
 plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
-plugins/module_utils/addon_utils.py import-3.5 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.6 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.7 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.8 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.9 # TODO issue #32
+plugins/module_utils/addon_utils.py import-3.5 # Python 3.5 is not supported
 plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported
 plugins/module_utils/addon_utils.py compile-2.7!skip # Python 2.x is not supported
 plugins/module_utils/addon_utils.py compile-3.5!skip # Python 3.5 is not supported
-plugins/module_utils/addon_utils.py pylint:ansible-bad-module-import # TODO issue #33
 plugins/modules/cluster_proxy_addon.py import-2.6 # Python 2.x is not supported
 plugins/modules/cluster_proxy_addon.py import-2.7 # Python 2.x is not supported
-plugins/modules/cluster_proxy_addon.py import-3.5 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.6 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.7 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.8 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.9 # TODO issue #32
+plugins/modules/cluster_proxy_addon.py import-3.5 # Python 3.5 is not supported
 plugins/modules/cluster_proxy_addon.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy_addon.py compile-2.7!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy_addon.py compile-3.5!skip # Python 3.5 is not supported
-plugins/modules/cluster_proxy_addon.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/cluster_proxy_addon.py validate-modules!skip # TODO 
 plugins/modules/managed_serviceaccount_addon.py import-2.6 # Python 2.x is not supported
 plugins/modules/managed_serviceaccount_addon.py import-2.7 # Python 2.x is not supported
-plugins/modules/managed_serviceaccount_addon.py import-3.5 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.6 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.7 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.8 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.9 # TODO issue #32
+plugins/modules/managed_serviceaccount_addon.py import-3.5 # Python 3.5 is not supported
 plugins/modules/managed_serviceaccount_addon.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/managed_serviceaccount_addon.py compile-2.7!skip # Python 2.x is not supported
 plugins/modules/managed_serviceaccount_addon.py compile-3.5!skip # Python 3.5 is not supported
-plugins/modules/managed_serviceaccount_addon.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/managed_serviceaccount_addon.py validate-modules!skip # TODO
 plugins/inventory/ocm_managedcluster.py compile-2.6!skip # Python 2.x is not supported
 plugins/inventory/ocm_managedcluster.py compile-2.7!skip # Python 2.x is not supported
 plugins/inventory/ocm_managedcluster.py compile-3.5!skip # Python 3.5 is not supported
 plugins/inventory/ocm_managedcluster.py import-2.7 # Python 2.x is not supported
-plugins/inventory/ocm_managedcluster.py import-3.5 # TODO issue #32
+plugins/inventory/ocm_managedcluster.py import-3.5 # Python 3.5 is not supported

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,62 +1,6 @@
-plugins/modules/import_eks.py import-2.6 # Python 2.x is not supported
-plugins/modules/import_eks.py import-2.7 # Python 2.x is not supported
-plugins/modules/import_eks.py import-3.5 # TODO issue #32
-plugins/modules/import_eks.py import-3.6 # TODO issue #32
-plugins/modules/import_eks.py import-3.7 # TODO issue #32
-plugins/modules/import_eks.py import-3.8 # TODO issue #32
-plugins/modules/import_eks.py import-3.9 # TODO issue #32
-plugins/modules/import_eks.py import-3.10 # TODO issue #32
-plugins/modules/import_eks.py compile-2.6!skip # Python 2.x is not supported
-plugins/modules/import_eks.py compile-2.7!skip # Python 2.x is not supported
-plugins/modules/import_eks.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/module_utils/import_utils.py import-2.6 # Python 2.x is not supported
-plugins/module_utils/import_utils.py import-2.7 # Python 2.x is not supported
-plugins/module_utils/import_utils.py import-3.5 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.6 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.7 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.8 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.9 # TODO issue #32
-plugins/module_utils/import_utils.py import-3.10 # TODO issue #32
-plugins/module_utils/import_utils.py compile-2.6!skip # Python 2.x is not supported
-plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not supported
-plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
-plugins/module_utils/import_utils.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/import_eks.py validate-modules!skip # TODO 
-plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
-plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
-plugins/module_utils/addon_utils.py import-3.5 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.6 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.7 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.8 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.9 # TODO issue #32
-plugins/module_utils/addon_utils.py import-3.10 # TODO issue #32
-plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported
-plugins/module_utils/addon_utils.py compile-2.7!skip # Python 2.x is not supported
-plugins/module_utils/addon_utils.py compile-3.5!skip # Python 3.5 is not supported
-plugins/module_utils/addon_utils.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/cluster_proxy_addon.py import-2.6 # Python 2.x is not supported
-plugins/modules/cluster_proxy_addon.py import-2.7 # Python 2.x is not supported
-plugins/modules/cluster_proxy_addon.py import-3.5 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.6 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.7 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.8 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.9 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py import-3.10 # TODO issue #32
-plugins/modules/cluster_proxy_addon.py compile-2.6!skip # Python 2.x is not supported
-plugins/modules/cluster_proxy_addon.py compile-2.7!skip # Python 2.x is not supported
-plugins/modules/cluster_proxy_addon.py compile-3.5!skip # Python 3.5 is not supported
-plugins/modules/cluster_proxy_addon.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/cluster_proxy_addon.py validate-modules!skip # TODO 
-plugins/modules/managed_serviceaccount_addon.py import-2.6 # Python 2.x is not supported
-plugins/modules/managed_serviceaccount_addon.py import-2.7 # Python 2.x is not supported
-plugins/modules/managed_serviceaccount_addon.py import-3.5 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.6 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.7 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.8 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.9 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py import-3.10 # TODO issue #32
-plugins/modules/managed_serviceaccount_addon.py compile-2.6!skip # Python 2.x is not supported
-plugins/modules/managed_serviceaccount_addon.py compile-2.7!skip # Python 2.x is not supported
-plugins/modules/managed_serviceaccount_addon.py compile-3.5!skip # Python 3.5 is not supported
-plugins/modules/managed_serviceaccount_addon.py pylint:ansible-bad-module-import # TODO issue #33
-plugins/modules/managed_serviceaccount_addon.py validate-modules!skip # TODO
+plugins/modules/import_eks.py import-3.6 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.7 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.8 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.9 # amazon.aws collection is required
+plugins/modules/import_eks.py import-3.10 # amazon.aws collection is required
+plugins/modules/import_eks.py validate-modules!skip # amazon.aws collection is required


### PR DESCRIPTION
AnsibleError should not be referenced directly in any places. It's used for ansible to fire exceptions.

For modules, if we want to raise errors, we should use module.fail_json() instead.

Updates:
- removed use of AnsibleError, and use module.fail_json instead
- reduced number of ignored lines for sanity tests

Tests:
- [x] eks plugin still works
- [x] inventory plugin still works 
- [x] cluster proxy plugin still works (first time use with 60 seconds polling)
- [x] managed-serviceaccount plugin still works (first time use with 60 seconds polling)

Notes:
- we still have errors in sanity test about missing collection dependencies, and this can be solved by running ansible-galaxy install before sanity test.

Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>