### PR TITLE
add cluster-management-addon plugin

### DIFF
--- a/plugins/module_utils/managedcluster_addons/cluster_proxy.py
+++ b/plugins/module_utils/managedcluster_addons/cluster_proxy.py
@@ -4,19 +4,30 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 from .addon_base import addon_base
-
+import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+IMP_ERR = {}
+try:
+    from kubernetes.dynamic.exceptions import DynamicApiError
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
 
 # subclass
+
+
 class cluster_proxy(addon_base):
     def __init__(self, module: AnsibleModule, hub_client, managed_cluster_name, addon_name, wait=False, timeout=60):
         super().__init__(module, hub_client, managed_cluster_name, addon_name, wait, timeout)
+        if 'k8s' in IMP_ERR:
+            module.fail_json(msg=missing_required_lib('kubernetes'),
+                             exception=IMP_ERR['k8s']['exception'])
 
     def check_feature(self):
-        self.check_multi_cluster_hub_feature(
-            self.module,
-            self.hub_client,
-            self.addon_name
-        )
+        mch = self.get_multi_cluster_hub()
+        if not self.get_multi_cluster_hub_feature_enablement(mch):
+            self.module.fail_json(
+                msg=f'failed to check feature: {self.addon_name} is not enabled')
 
     def enable_addon(self):
         return self.enable_managed_cluster_addon(
@@ -37,3 +48,67 @@ class cluster_proxy(addon_base):
             self.wait,
             self.timeout
         )
+
+    def enable_feature(self):
+        mch = self.get_multi_cluster_hub()
+        changed = False
+        if not self.get_multi_cluster_hub_feature_enablement(mch):
+            # need to update mch
+            self.update_multi_cluster_hub_feature(mch, True)
+            changed = True
+
+        # if self.wait:
+            # waiting for clusterdeployment is not doable
+
+            # cluster_management_addon_api = self.hub_client.resources.get(
+            #     api_version='addon.open-cluster-management.io/v1alpha1',
+            #     kind='ClusterManagementAddOn',
+            # )
+            # try:
+            #     cluster_management_addon_api.get(name=self.addon_name)
+            # except NotFoundError:
+            #     if not self.wait_for_feature_enabled():
+            #         self.module.fail_json(msg=f'timeout waiting for the feature {self.addon_name} to be enabled.')
+        return changed
+
+    def disable_feature(self):
+        mch = self.get_multi_cluster_hub()
+        changed = False
+        if self.get_multi_cluster_hub_feature_enablement(mch):
+            # need to update mch
+            changed = True
+            self.update_multi_cluster_hub_feature(mch, False)
+        return changed
+
+    def update_multi_cluster_hub_feature(self, mch, state=False):
+        mch_api = self.hub_client.resources.get(
+            api_version="operator.open-cluster-management.io/v1",
+            kind="MultiClusterHub",
+        )
+        patch_body = {
+            "apiVersion": "operator.open-cluster-management.io/v1",
+            "kind": "MultiClusterHub",
+            "metadata": {
+                "name": mch.metadata.name,
+                "namespace": mch.metadata.namespace,
+            },
+            "spec": {
+                "enableClusterProxyAddon": state,
+            },
+        }
+        try:
+            mch_api.patch(body=patch_body,
+                          content_type="application/merge-patch+json")
+        except DynamicApiError as e:
+            self.module.fail_json(
+                msg=f'failed to patch MultiClusterHub {mch.metadata.name} in {mch.metadata.namespace} namespace.', err=e)
+
+    def get_multi_cluster_hub_feature_enablement(self, mch):
+        mch_feature_path = ['spec', 'enableClusterProxyAddon']
+        curr = mch
+        for p in mch_feature_path[:-1]:
+            next = curr.get(p)
+            if next is None:
+                return False
+            curr = next
+        return curr.get(mch_feature_path[-1]) is True

--- a/plugins/module_utils/managedcluster_addons/managed_serviceaccount.py
+++ b/plugins/module_utils/managedcluster_addons/managed_serviceaccount.py
@@ -4,19 +4,26 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 from .addon_base import addon_base
+import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+IMP_ERR = {}
+try:
+    from kubernetes.dynamic.exceptions import NotFoundError, DynamicApiError
+    from kubernetes.client.exceptions import ApiException
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
 
 
 # subclass
 class managed_serviceaccount(addon_base):
     def __init__(self, module: AnsibleModule, hub_client, managed_cluster_name, addon_name, wait=False, timeout=60):
         super().__init__(module, hub_client, managed_cluster_name, addon_name, wait, timeout)
+        if 'k8s' in IMP_ERR:
+            module.fail_json(msg=missing_required_lib('kubernetes'),
+                             exception=IMP_ERR['k8s']['exception'])
 
     def check_feature(self):
-        # self.check_multi_cluster_hub_feature(
-        #    self.module,
-        #    self.hub_client,
-        #    self.addon_name
-        # )
         self.check_cluster_management_addon_feature(
             self.module,
             self.hub_client,
@@ -42,3 +49,73 @@ class managed_serviceaccount(addon_base):
             self.wait,
             self.timeout
         )
+
+    def enable_feature(self):
+        mch = self.get_multi_cluster_hub()
+        changed = False
+        if not self.get_multi_cluster_hub_feature_enablement(mch):
+            # need to update mch
+            self.update_multi_cluster_hub_feature(mch, True)
+            changed = True
+
+        if self.wait:
+            # wait clusterdeployment to be created
+            cluster_management_addon_api = self.hub_client.resources.get(
+                api_version='addon.open-cluster-management.io/v1alpha1',
+                kind='ClusterManagementAddOn',
+            )
+            try:
+                cluster_management_addon_api.get(name=self.addon_name)
+            except NotFoundError:
+                if not self.wait_for_feature_enabled():
+                    self.module.fail_json(
+                        msg=f'timeout waiting for the feature {self.addon_name} to be enabled.')
+
+        return changed
+
+    def disable_feature(self):
+        mch = self.get_multi_cluster_hub()
+        changed = False
+        if self.get_multi_cluster_hub_feature_enablement(mch):
+            # need to update mch
+            changed = True
+            self.update_multi_cluster_hub_feature(mch, False)
+        return changed
+
+    def update_multi_cluster_hub_feature(self, mch, state=False):
+        mch_api = self.hub_client.resources.get(
+            api_version="operator.open-cluster-management.io/v1",
+            kind="MultiClusterHub",
+        )
+        patch_body = {
+            "apiVersion": "operator.open-cluster-management.io/v1",
+            "kind": "MultiClusterHub",
+            "metadata": {
+                "name": mch.metadata.name,
+                "namespace": mch.metadata.namespace,
+            },
+            "spec": {
+                "componentConfig": {
+                    "managedServiceAccount": {
+                        "enable": state,
+                    },
+                },
+            },
+        }
+        try:
+            mch_api.patch(body=patch_body,
+                          content_type="application/merge-patch+json")
+        except DynamicApiError as e:
+            self.module.fail_json(
+                msg=f'failed to patch MultiClusterHub {mch.metadata.name} in {mch.metadata.namespace} namespace.', err=e)
+
+    def get_multi_cluster_hub_feature_enablement(self, mch):
+        mch_feature_path = ['spec', 'componentConfig',
+                            'managedServiceAccount', 'enable']
+        curr = mch
+        for p in mch_feature_path[:-1]:
+            next = curr.get(p)
+            if next is None:
+                return False
+            curr = next
+        return curr.get(mch_feature_path[-1]) is True

--- a/plugins/module_utils/managedcluster_addons/search_collector.py
+++ b/plugins/module_utils/managedcluster_addons/search_collector.py
@@ -4,19 +4,30 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 from .addon_base import addon_base
-
+import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+IMP_ERR = {}
+try:
+    from kubernetes.dynamic.exceptions import DynamicApiError
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
 
 # subclass
+
+
 class search_collector(addon_base):
     def __init__(self, module: AnsibleModule, hub_client, managed_cluster_name, addon_name, wait=False, timeout=60):
         super().__init__(module, hub_client, managed_cluster_name, addon_name, wait, timeout)
+        if 'k8s' in IMP_ERR:
+            module.fail_json(msg=missing_required_lib('kubernetes'),
+                             exception=IMP_ERR['k8s']['exception'])
 
     def check_feature(self):
-        self.check_cluster_management_addon_feature(
-            self.module,
-            self.hub_client,
-            self.addon_name
-        )
+        mch = self.get_multi_cluster_hub()
+        if not self.get_multi_cluster_hub_feature_enablement(mch):
+            self.module.fail_json(
+                msg=f'failed to check feature: {self.addon_name} is not enabled')
 
     def enable_addon(self):
         return self.enable_klusterlet_addon(
@@ -37,3 +48,70 @@ class search_collector(addon_base):
             self.wait,
             self.timeout
         )
+
+    def enable_feature(self):
+        mch = self.get_multi_cluster_hub()
+        changed = False
+        if not self.get_multi_cluster_hub_feature_enablement(mch):
+            # need to update mch
+            self.update_multi_cluster_hub_feature(mch, True)
+            changed = True
+        # if self.wait:
+            # waiting for clusterdeployment is not doable
+
+            # cluster_management_addon_api = self.hub_client.resources.get(
+            #     api_version='addon.open-cluster-management.io/v1alpha1',
+            #     kind='ClusterManagementAddOn',
+            # )
+            # try:
+            #     cluster_management_addon_api.get(name=self.addon_name)
+            # except NotFoundError:
+            #     if not self.wait_for_feature_enabled():
+            #         self.module.fail_json(msg=f'timeout waiting for the feature {self.addon_name} to be enabled.')
+        return changed
+
+    def disable_feature(self):
+        mch = self.get_multi_cluster_hub()
+        changed = False
+        if self.get_multi_cluster_hub_feature_enablement(mch):
+            # need to update mch
+            changed = True
+            self.update_multi_cluster_hub_feature(mch, False)
+        return changed
+
+    def update_multi_cluster_hub_feature(self, mch, state=False):
+        mch_api = self.hub_client.resources.get(
+            api_version="operator.open-cluster-management.io/v1",
+            kind="MultiClusterHub",
+        )
+        patch_body = {
+            "apiVersion": "operator.open-cluster-management.io/v1",
+            "kind": "MultiClusterHub",
+            "metadata": {
+                "name": mch.metadata.name,
+                "namespace": mch.metadata.namespace,
+            },
+            "spec": {
+                "componentConfig": {
+                    "search": {
+                        "disable": not state,
+                    },
+                },
+            },
+        }
+        try:
+            mch_api.patch(body=patch_body,
+                          content_type="application/merge-patch+json")
+        except DynamicApiError as e:
+            self.module.fail_json(
+                msg=f'failed to patch MultiClusterHub {mch.metadata.name} in {mch.metadata.namespace} namespace.', err=e)
+
+    def get_multi_cluster_hub_feature_enablement(self, mch):
+        mch_feature_path = ['spec', 'componentConfig', 'search', 'disable']
+        curr = mch
+        for p in mch_feature_path[:-1]:
+            next = curr.get(p)
+            if next is None:
+                return True
+            curr = next
+        return curr.get(mch_feature_path[-1]) is False

--- a/plugins/modules/cluster_management_addon.py
+++ b/plugins/modules/cluster_management_addon.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+
+module: cluster_management_addon
+
+short_description: cluster management addon
+
+author:
+- "Hao Liu (@TheRealHaoLiu)"
+- "Hanqiu Zhang (@hanqiuzh)"
+- "Nathan Weatherly (@nathanweatherly)"
+- "Tsu Phin Hee (@tphee)"
+
+description:
+- Use cluster_management_addon to enable/disable a feature on the hub.
+  Users can only install an addon on managed clusters if the feature of that addon is enabled.
+  This plugin will need access to the Multicloudhub CR, and it enables/disables available features by updating the corresponding fields in the CR.
+
+options:
+    hub_kubeconfig:
+        description: Path to the Hub cluster kubeconfig. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.
+        type: str
+        required: True
+    wait:
+        description: Whether to wait for an addon feature to show up. This configuration will be ignored when the state is 'absent'.
+        type: bool
+        default: False
+        required: False
+    timeout:
+        description: Number of seconds to wait for the addon to show up.
+        type: int
+        default: 60
+        required: False
+    addon_name:
+        description: Name of the feature to enable/disable.
+        type: str
+        choices: [
+                    cluster-proxy,
+                    managed-serviceaccount,
+                    search-collector,
+                 ]
+        required: True
+    state:
+        description:
+        - Determines if feature should be enabled, or disabled. When set to C(present),
+          a feature will be enabled. If set to C(absent), an existing feature will be disabled.
+        type: str
+        default: present
+        choices: [ absent, present ]
+        required: False
+'''
+
+EXAMPLES = r'''
+- name: "Enabled cluster-proxy addon"
+  ocmplus.cm.cluster_management_addon:
+    state: present
+    hub_kubeconfig: /path/to/hub/kubeconfig
+    addon_name: cluster-proxy
+
+- name: "Disabled cluster-proxy addon"
+  ocmplus.cm.cluster_management_addon:
+    state: absent
+    hub_kubeconfig: /path/to/hub/kubeconfig
+    addon_name: cluster-proxy
+'''
+
+RETURN = r'''
+result:
+    description: message describing the addon enabled/disabled successfully done.
+    returned: success
+    type: str
+err:
+  description: Error message
+  returned: when there's an error
+  type: str
+  sample: null
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback, missing_required_lib
+from ansible_collections.ocmplus.cm.plugins.module_utils.managedcluster_addons.cluster_proxy import cluster_proxy
+from ansible_collections.ocmplus.cm.plugins.module_utils.managedcluster_addons.managed_serviceaccount import managed_serviceaccount
+from ansible_collections.ocmplus.cm.plugins.module_utils.managedcluster_addons.search_collector import search_collector
+
+IMP_ERR = {}
+try:
+    import kubernetes
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
+
+
+def execute_module(module: AnsibleModule):
+    if 'k8s' in IMP_ERR:
+        # we will need k8s for this module
+        module.fail_json(msg=missing_required_lib('kubernetes'),
+                         exception=IMP_ERR['k8s']['exception'])
+
+    addon_name = module.params['addon_name']
+    hub_kubeconfig = kubernetes.config.load_kube_config(
+        config_file=module.params['hub_kubeconfig'])
+    hub_client = kubernetes.dynamic.DynamicClient(
+        kubernetes.client.api_client.ApiClient(configuration=hub_kubeconfig)
+    )
+    wait = module.params['wait']
+    timeout = module.params['timeout']
+    if timeout is None or timeout <= 0:
+        timeout = 60
+
+    state = module.params['state']
+    enabled = True if state == 'present' else False
+    new_addon_name = addon_name.replace('-', '_')
+    new_addon = globals()[new_addon_name](module, hub_client,
+                                          '', addon_name, wait, timeout)
+    changed = False
+    if enabled:
+        changed = new_addon.enable_feature()
+    else:
+        changed = new_addon.disable_feature()
+
+    module.exit_json(
+        changed=changed, result=f'Addon feature {addon_name} is {"enabled" if enabled else "disabled"}.')
+
+
+def main():
+    addon_choices = ['cluster-proxy',
+                     'managed-serviceaccount', 'search-collector']
+
+    argument_spec = dict(
+        hub_kubeconfig=dict(type='str', required=True, fallback=(
+            env_fallback, ['K8S_AUTH_KUBECONFIG'])),
+        addon_name=dict(
+            type='str',
+            choices=addon_choices,
+            required=True
+        ),
+        wait=dict(type='bool', required=False, default=False),
+        timeout=dict(type='int', required=False, default=60),
+        state=dict(
+            type="str",
+            default="present",
+            choices=["present", "absent"],
+            required=False
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -68,6 +68,12 @@ plugins/modules/cluster_proxy.py import-3.5 # Python 3.5 is not supported
 plugins/modules/cluster_proxy.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy.py compile-2.7!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/cluster_management_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py import-3.5 # Python 3.5 is not supported
+plugins/modules/cluster_management_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py compile-3.5!skip # Python 3.5 is not supported
 plugins/modules/managed_serviceaccount.py import-2.6 # Python 2.x is not supported
 plugins/modules/managed_serviceaccount.py import-2.7 # Python 2.x is not supported
 plugins/modules/managed_serviceaccount.py import-3.5 # Python 3.5 is not supported

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -68,6 +68,12 @@ plugins/modules/cluster_proxy.py import-3.5 # Python 3.5 is not supported
 plugins/modules/cluster_proxy.py compile-2.6!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy.py compile-2.7!skip # Python 2.x is not supported
 plugins/modules/cluster_proxy.py compile-3.5!skip # Python 3.5 is not supported
+plugins/modules/cluster_management_addon.py import-2.6 # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py import-2.7 # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py import-3.5 # Python 3.5 is not supported
+plugins/modules/cluster_management_addon.py compile-2.6!skip # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py compile-2.7!skip # Python 2.x is not supported
+plugins/modules/cluster_management_addon.py compile-3.5!skip # Python 3.5 is not supported
 plugins/modules/managed_serviceaccount.py import-2.6 # Python 2.x is not supported
 plugins/modules/managed_serviceaccount.py import-2.7 # Python 2.x is not supported
 plugins/modules/managed_serviceaccount.py import-3.5 # Python 3.5 is not supported


### PR DESCRIPTION
Updates:
- added feature enablement for the following addons
   - cluster-proxy
   - managed-serviceaccount
   - search-collector

Testes:
- [x] can enable/disable managed-serviceaccount in mch
- [x] will wait managed-serviceaccount's clustermanagement addon if wait is enabled
- [x] can enable/disable cluster-proxy in mch
- [x] can enable/disable search in mch

Notes:
- currently only wait for enabling of features, and only `managed-serviceaccount` will work, as wait we are waiting for creation of clustermanagementaddon
- to align with addon, named search feature to be `search-collector`
- if search is disabled, only hub components will be disabled, but user can still enable addons across the cluster by using klusterletaddonconfig 😢 

Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>