### PR TITLE
update the cluster-management-addon plugin to use latest MCH/MCE api

### DIFF
--- a/plugins/module_utils/installer_utils.py
+++ b/plugins/module_utils/installer_utils.py
@@ -1,0 +1,152 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import traceback
+
+IMP_ERR = {}
+try:
+    from kubernetes.dynamic.exceptions import NotFoundError, DynamicApiError, ResourceNotFoundError
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
+
+
+def get_multi_cluster_hub(hub_client, module, ignore_not_found=False):
+    """
+    get_multi_cluster_hub lists mch of the cluster, and returns the first one.
+    If ignore_not_found is set, will simply return None without sending any errors.
+    """
+
+    # get all instance of mch
+    try:
+        mch_api = hub_client.resources.get(
+            api_version="operator.open-cluster-management.io/v1",
+            kind="MultiClusterHub",
+        )
+        mch_list = mch_api.get()
+    except (ResourceNotFoundError, NotFoundError) as e:
+        if not ignore_not_found:
+            module.fail_json(msg=f'failed to list MultiClusterHub: {e}')
+        return None
+
+    if not ignore_not_found and len(mch_list.get('items', [])) < 1:
+        module.fail_json(
+            msg='failed to get MultiClusterHub.')
+
+    if len(mch_list.get('items', [])) < 1:
+        return None
+
+    first_mch = mch_list.items[0]
+    mch = None
+    # get mch directly for return
+    try:
+        mch = mch_api.get(name=first_mch.metadata.name,
+                          namespace=first_mch.metadata.namespace)
+    except DynamicApiError as e:
+        module.fail_json(
+            msg=f'failed to get MultiClusterHub {first_mch.metadata.name} in {first_mch.metadata.namespace} namespace: {e}')
+
+    return mch
+
+
+def get_multi_cluster_engine(hub_client, module):
+    """
+    get_multi_cluster_engine lists mce of the cluster, and returns the first one.
+    """
+    # get all instance of mce
+    try:
+        mce_api = hub_client.resources.get(
+            api_version="multicluster.openshift.io/v1",
+            kind="MultiClusterEngine",
+        )
+        mce_list = mce_api.get()
+        if len(mce_list.get('items', [])) < 1:
+            if module is not None:
+                module.fail_json(
+                    'failed to get MultiClusterEngine.')
+            return None
+    except DynamicApiError as e:
+        if module is not None:
+            module.fail_json(
+                f'failed to get MultiClusterEngine: {e}.')
+        return None
+
+    first_mce = mce_list.items[0]
+    mce = None
+    # get mce directly for return
+    try:
+        mce = mce_api.get(name=first_mce.metadata.name,
+                          namespace=first_mce.metadata.namespace)
+    except DynamicApiError as e:
+        module.fail_json(
+            msg=f'failed to get MultiClusterEngine {first_mce.metadata.name}: {e}')
+
+    return mce
+
+
+def get_component_status(obj, module, component_name: str):
+    """
+    get_component_status returns a boolean to indicate if a certain component is enabled or disabled.
+    obj can be either a dict of a MCH CR, or a dict of a MCE CR.
+    If the component_name is not existed in the spec.components list, will return False.
+    """
+    if obj is None:
+        return False
+    obj_feature_path = ['spec', 'overrides', 'components']
+    curr = obj
+    for p in obj_feature_path:
+        next = curr.get(p)
+        if next is None:
+            return False
+        curr = next
+    components = curr
+    try:
+        for component in components:
+            if component.get('name', '') != component_name:
+                continue
+            return component.get('enabled', False)
+    except (TypeError, AttributeError) as e:
+        module.fail_json(
+            msg=f'failed to get enablement status of component {component_name}: {e}')
+
+    return False
+
+
+def set_component_status(obj, module, component_name: str, enabled: bool):
+    """
+    set_component_status sets the given obj with the given enabled status in place.
+    obj can be either a dict of a MCH CR, or a dict of a MCE CR.
+    If the obj is empty or doesn't has a spec field, will fail with error.
+    If the component is in the obj spec.components, it will be updated directly;
+    otherwise, it will be appended to the spec.components list.
+    """
+    if obj is None:
+        module.fail_json(
+            msg=f'failed to set enablement status of component {component_name} in None object')
+        return
+    if obj.get('spec') is None:
+        module.fail_json(
+            msg=f'failed to set enablement status of component {component_name} in object {obj}')
+        return
+    spec = obj.get('spec')
+    try:
+        if 'overrides' not in spec.keys():
+            spec['overrides'] = {}
+        overrides = spec['overrides']
+        if 'components' not in overrides.keys():
+            overrides['components'] = []
+        hasComponent = False
+        for component in overrides['components']:
+            if component.get('name', '') == component_name:
+                hasComponent = True
+                if component.get('enabled', False) != enabled:
+                    component['enabled'] = enabled
+        if not hasComponent:
+            overrides['components'].append({
+                'name': component_name,
+                'enabled': enabled,
+            })
+    except (TypeError, AttributeError) as e:
+        module.fail_json(
+            msg=f'failed to set enablement status of component {component_name}: {e}')

--- a/plugins/module_utils/managedcluster_addons/addon_base.py
+++ b/plugins/module_utils/managedcluster_addons/addon_base.py
@@ -63,66 +63,6 @@ class addon_base():
     def disable_feature(self):
         pass
 
-    def get_multi_cluster_hub(self, ignore_not_found=False):
-        # get all instance of mch
-        try:
-            mch_api = self.hub_client.resources.get(
-                api_version="operator.open-cluster-management.io/v1",
-                kind="MultiClusterHub",
-            )
-            mch_list = mch_api.get()
-        except (ResourceNotFoundError, NotFoundError) as e:
-            if not ignore_not_found:
-                self.module.fail_json(
-                    msg=f'failed to list MultiClusterHub: {e}')
-            else:
-                return None
-
-        if ignore_not_found and len(mch_list.get('items', [])) < 1:
-            return None
-        elif len(mch_list.get('items', [])) < 1:
-            self.module.fail_json(
-                msg='failed to get MultiClusterHub.')
-
-        first_mch = mch_list.items[0]
-        mch = None
-        # get mch directly for return
-        try:
-            mch = mch_api.get(name=first_mch.metadata.name,
-                              namespace=first_mch.metadata.namespace)
-        except DynamicApiError as e:
-            self.module.fail_json(
-                msg=f'failed to get MultiClusterHub {first_mch.metadata.name} in {first_mch.metadata.namespace} namespace: {e}')
-
-        return mch
-
-    def get_multi_cluster_engine(self):
-        # get all instance of mch
-        try:
-            mce_api = self.hub_client.resources.get(
-                api_version="multicluster.openshift.io/v1",
-                kind="MultiClusterEngine",
-            )
-            mce_list = mce_api.get()
-            if len(mce_list.get('items', [])) < 1:
-                self.module.fail_json(
-                    msg='failed to get MultiClusterEngine.')
-        except DynamicApiError as e:
-            self.module.fail_json(
-                msg=f'failed to get MultiClusterEngine: {e}.')
-
-        first_mce = mce_list.items[0]
-        mce = None
-        # get mch directly for return
-        try:
-            mce = mce_api.get(name=first_mce.metadata.name,
-                              namespace=first_mce.metadata.namespace)
-        except DynamicApiError as e:
-            self.module.fail_json(
-                msg=f'failed to get MultiClusterEngine {first_mce.metadata.name}: {e}')
-
-        return mce
-
     def wait_for_feature_enabled(self) -> bool:
         cluster_management_addon_api = self.hub_client.resources.get(
             api_version='addon.open-cluster-management.io/v1alpha1',

--- a/plugins/module_utils/managedcluster_addons/cluster_proxy.py
+++ b/plugins/module_utils/managedcluster_addons/cluster_proxy.py
@@ -6,9 +6,10 @@ from ansible.module_utils.basic import AnsibleModule
 from .addon_base import addon_base
 import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.ocmplus.cm.plugins.module_utils.installer_utils import get_multi_cluster_hub, get_component_status, set_component_status
 IMP_ERR = {}
 try:
-    from kubernetes.dynamic.exceptions import DynamicApiError
+    from kubernetes.dynamic.exceptions import DynamicApiError, NotFoundError
 except ImportError as e:
     IMP_ERR['k8s'] = {'error': traceback.format_exc(),
                       'exception': e}
@@ -22,12 +23,14 @@ class cluster_proxy(addon_base):
         if 'k8s' in IMP_ERR:
             module.fail_json(msg=missing_required_lib('kubernetes'),
                              exception=IMP_ERR['k8s']['exception'])
+        self.component_name = 'cluster-proxy-addon'
 
     def check_feature(self):
-        mch = self.get_multi_cluster_hub()
-        if not self.get_multi_cluster_hub_feature_enablement(mch):
-            self.module.fail_json(
-                msg=f'failed to check feature: {self.addon_name} is not enabled')
+        self.check_cluster_management_addon_feature(
+            self.module,
+            self.hub_client,
+            self.addon_name
+        )
 
     def enable_addon(self):
         return self.enable_managed_cluster_addon(
@@ -50,31 +53,30 @@ class cluster_proxy(addon_base):
         )
 
     def enable_feature(self):
-        mch = self.get_multi_cluster_hub()
+        mch = get_multi_cluster_hub(self.hub_client, self.module).to_dict()
         changed = False
-        if not self.get_multi_cluster_hub_feature_enablement(mch):
+        if not get_component_status(mch, self.module, self.component_name):
             # need to update mch
             self.update_multi_cluster_hub_feature(mch, True)
             changed = True
 
-        # if self.wait:
-            # waiting for clusterdeployment is not doable
-
-            # cluster_management_addon_api = self.hub_client.resources.get(
-            #     api_version='addon.open-cluster-management.io/v1alpha1',
-            #     kind='ClusterManagementAddOn',
-            # )
-            # try:
-            #     cluster_management_addon_api.get(name=self.addon_name)
-            # except NotFoundError:
-            #     if not self.wait_for_feature_enabled():
-            #         self.module.fail_json(msg=f'timeout waiting for the feature {self.addon_name} to be enabled.')
+        if self.wait:
+            cluster_management_addon_api = self.hub_client.resources.get(
+                api_version='addon.open-cluster-management.io/v1alpha1',
+                kind='ClusterManagementAddOn',
+            )
+            try:
+                cluster_management_addon_api.get(name=self.addon_name)
+            except NotFoundError:
+                if not self.wait_for_feature_enabled():
+                    self.module.fail_json(
+                        msg=f'timeout waiting for the feature {self.addon_name} to be enabled.')
         return changed
 
     def disable_feature(self):
-        mch = self.get_multi_cluster_hub()
+        mch = get_multi_cluster_hub(self.hub_client, self.module).to_dict()
         changed = False
-        if self.get_multi_cluster_hub_feature_enablement(mch):
+        if get_component_status(mch, self.module, self.component_name):
             # need to update mch
             changed = True
             self.update_multi_cluster_hub_feature(mch, False)
@@ -85,30 +87,13 @@ class cluster_proxy(addon_base):
             api_version="operator.open-cluster-management.io/v1",
             kind="MultiClusterHub",
         )
-        patch_body = {
-            "apiVersion": "operator.open-cluster-management.io/v1",
-            "kind": "MultiClusterHub",
-            "metadata": {
-                "name": mch.metadata.name,
-                "namespace": mch.metadata.namespace,
-            },
-            "spec": {
-                "enableClusterProxyAddon": state,
-            },
-        }
+        set_component_status(mch, self.module, self.component_name, state)
         try:
-            mch_api.patch(body=patch_body,
-                          content_type="application/merge-patch+json")
+            mch_api.patch(
+                name=mch.get('metadata', {}).get('name'),
+                namespace=mch.get('metadata', {}).get('namespace'),
+                body=mch,
+                content_type="application/merge-patch+json")
         except DynamicApiError as e:
             self.module.fail_json(
                 msg=f'failed to patch MultiClusterHub {mch.metadata.name} in {mch.metadata.namespace} namespace.', err=e)
-
-    def get_multi_cluster_hub_feature_enablement(self, mch):
-        mch_feature_path = ['spec', 'enableClusterProxyAddon']
-        curr = mch
-        for p in mch_feature_path[:-1]:
-            next = curr.get(p)
-            if next is None:
-                return False
-            curr = next
-        return curr.get(mch_feature_path[-1]) is True

--- a/plugins/module_utils/managedcluster_addons/search_collector.py
+++ b/plugins/module_utils/managedcluster_addons/search_collector.py
@@ -6,6 +6,7 @@ from ansible.module_utils.basic import AnsibleModule
 from .addon_base import addon_base
 import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.ocmplus.cm.plugins.module_utils.installer_utils import get_multi_cluster_hub, get_component_status, set_component_status
 IMP_ERR = {}
 try:
     from kubernetes.dynamic.exceptions import DynamicApiError
@@ -22,10 +23,11 @@ class search_collector(addon_base):
         if 'k8s' in IMP_ERR:
             module.fail_json(msg=missing_required_lib('kubernetes'),
                              exception=IMP_ERR['k8s']['exception'])
+        self.component_name = 'search'
 
     def check_feature(self):
         mch = self.get_multi_cluster_hub()
-        if not self.get_multi_cluster_hub_feature_enablement(mch):
+        if not get_component_status(mch, self.module, self.component_name):
             self.module.fail_json(
                 msg=f'failed to check feature: {self.addon_name} is not enabled')
 
@@ -50,30 +52,18 @@ class search_collector(addon_base):
         )
 
     def enable_feature(self):
-        mch = self.get_multi_cluster_hub()
+        mch = get_multi_cluster_hub(self.hub_client, self.module).to_dict()
         changed = False
-        if not self.get_multi_cluster_hub_feature_enablement(mch):
+        if not get_component_status(mch, self.module, self.component_name):
             # need to update mch
             self.update_multi_cluster_hub_feature(mch, True)
             changed = True
-        # if self.wait:
-            # waiting for clusterdeployment is not doable
-
-            # cluster_management_addon_api = self.hub_client.resources.get(
-            #     api_version='addon.open-cluster-management.io/v1alpha1',
-            #     kind='ClusterManagementAddOn',
-            # )
-            # try:
-            #     cluster_management_addon_api.get(name=self.addon_name)
-            # except NotFoundError:
-            #     if not self.wait_for_feature_enabled():
-            #         self.module.fail_json(msg=f'timeout waiting for the feature {self.addon_name} to be enabled.')
         return changed
 
     def disable_feature(self):
-        mch = self.get_multi_cluster_hub()
+        mch = get_multi_cluster_hub(self.hub_client, self.module).to_dict()
         changed = False
-        if self.get_multi_cluster_hub_feature_enablement(mch):
+        if get_component_status(mch, self.module, self.component_name):
             # need to update mch
             changed = True
             self.update_multi_cluster_hub_feature(mch, False)
@@ -84,34 +74,13 @@ class search_collector(addon_base):
             api_version="operator.open-cluster-management.io/v1",
             kind="MultiClusterHub",
         )
-        patch_body = {
-            "apiVersion": "operator.open-cluster-management.io/v1",
-            "kind": "MultiClusterHub",
-            "metadata": {
-                "name": mch.metadata.name,
-                "namespace": mch.metadata.namespace,
-            },
-            "spec": {
-                "componentConfig": {
-                    "search": {
-                        "disable": not state,
-                    },
-                },
-            },
-        }
+        set_component_status(mch, self.module, self.component_name, state)
         try:
-            mch_api.patch(body=patch_body,
-                          content_type="application/merge-patch+json")
+            mch_api.patch(
+                name=mch.get('metadata', {}).get('name'),
+                namespace=mch.get('metadata', {}).get('namespace'),
+                body=mch,
+                content_type="application/merge-patch+json")
         except DynamicApiError as e:
             self.module.fail_json(
                 msg=f'failed to patch MultiClusterHub {mch.metadata.name} in {mch.metadata.namespace} namespace.', err=e)
-
-    def get_multi_cluster_hub_feature_enablement(self, mch):
-        mch_feature_path = ['spec', 'componentConfig', 'search', 'disable']
-        curr = mch
-        for p in mch_feature_path[:-1]:
-            next = curr.get(p)
-            if next is None:
-                return True
-            curr = next
-        return curr.get(mch_feature_path[-1]) is False

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -9,6 +9,12 @@ plugins/module_utils/import_utils.py import-3.5 # Python 3.5 is not supported
 plugins/module_utils/import_utils.py compile-2.6!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
+plugins/module_utils/installer_utils.py import-2.6 # Python 2.x is not supported
+plugins/module_utils/installer_utils.py import-2.7 # Python 2.x is not supported
+plugins/module_utils/installer_utils.py import-3.5 # Python 3.5 is not supported
+plugins/module_utils/installer_utils.py compile-2.6!skip # Python 2.x is not supported
+plugins/module_utils/installer_utils.py compile-2.7!skip # Python 2.x is not supported
+plugins/module_utils/installer_utils.py compile-3.5!skip # Python 3.5 is not supported
 plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
 plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
 plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -9,6 +9,12 @@ plugins/module_utils/import_utils.py import-3.5 # Python 3.5 is not supported
 plugins/module_utils/import_utils.py compile-2.6!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-2.7!skip # Python 2.x is not supported
 plugins/module_utils/import_utils.py compile-3.5!skip # Python 3.5 is not supported
+plugins/module_utils/installer_utils.py import-2.6 # Python 2.x is not supported
+plugins/module_utils/installer_utils.py import-2.7 # Python 2.x is not supported
+plugins/module_utils/installer_utils.py import-3.5 # Python 3.5 is not supported
+plugins/module_utils/installer_utils.py compile-2.6!skip # Python 2.x is not supported
+plugins/module_utils/installer_utils.py compile-2.7!skip # Python 2.x is not supported
+plugins/module_utils/installer_utils.py compile-3.5!skip # Python 3.5 is not supported
 plugins/module_utils/addon_utils.py import-2.6 # Python 2.x is not supported
 plugins/module_utils/addon_utils.py import-2.7 # Python 2.x is not supported
 plugins/module_utils/addon_utils.py compile-2.6!skip # Python 2.x is not supported

--- a/tests/unit/plugins/module_utils/test_installer_utils.py
+++ b/tests/unit/plugins/module_utils/test_installer_utils.py
@@ -1,0 +1,234 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+from unittest.mock import MagicMock
+from ansible_collections.ocmplus.cm.plugins.module_utils.installer_utils import (
+    get_component_status,
+    set_component_status
+)
+
+
+class TestGetComponentStatus(unittest.TestCase):
+    def test_empty_input(self):
+        obj = None
+        module = MagicMock()
+        assert get_component_status(
+            obj, module, "test-component-name") is False
+        module.fail_json.assert_not_called()
+
+    def test_overrides_not_exist(self):
+        obj = {
+            "spec": {}
+        }
+        module = MagicMock()
+        assert get_component_status(
+            obj, module, "test-component-name") is False
+        module.fail_json.assert_not_called()
+
+    def test_components_not_exist(self):
+        obj = {
+            "spec": {"overrides": {}}
+        }
+        module = MagicMock()
+        assert get_component_status(
+            obj, module, "test-component-name") is False
+        module.fail_json.assert_not_called()
+
+    def test_components_empty(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": []
+            }}
+        }
+        module = MagicMock()
+        assert get_component_status(
+            obj, module, "test-component-name") is False
+        module.fail_json.assert_not_called()
+
+    def test_one_component_wrong_format(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": "wrong-format"
+            }}
+        }
+        module = MagicMock()
+        get_component_status(obj, module, "test-component-name")
+        module.fail_json.assert_called()
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    "test-component-name"
+                ]
+            }}
+        }
+        module = MagicMock()
+        get_component_status(obj, module, "test-component-name")
+        module.fail_json.assert_called()
+
+    def test_component_is_enabled(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    {
+                        "name": "test-component-name",
+                        "enabled": True,
+                    }
+                ]
+            }}
+        }
+        module = MagicMock()
+        assert get_component_status(obj, module, "test-component-name") is True
+        module.fail_json.assert_not_called()
+
+    def test_component_is_disabled(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    {
+                        "name": "test-component-name",
+                        "enabled": False,
+                    }
+                ]
+            }}
+        }
+        module = MagicMock()
+        assert get_component_status(
+            obj, module, "test-component-name") is False
+
+    def test_component_is_missing(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    {
+                        "name": "test-component-name",
+                        "enabled": False,
+                    }
+                ]
+            }}
+        }
+        module = MagicMock()
+        assert get_component_status(
+            obj, module, "test-component-name-different") is False
+
+
+class TestSetComponentStatus(unittest.TestCase):
+    def test_empty_input(self):
+        module = MagicMock()
+        set_component_status(None, module, "test-component-name", True)
+        module.fail_json.assert_called()
+
+    def test_empty_overrides(self):
+        obj = {
+            "spec": {"overrides": {}}
+        }
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", False)
+        module.fail_json.assert_not_called()
+        assert obj["spec"]["overrides"]["components"] == [{
+            "name": "test-component-name",
+            "enabled": False
+        }]
+
+    def test_empty_components(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": []
+            }}
+        }
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", False)
+        module.fail_json.assert_not_called()
+        assert obj["spec"]["overrides"]["components"] == [{
+            "name": "test-component-name",
+            "enabled": False
+        }]
+
+    def test_one_component_wrong_format(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": "wrong-format"
+            }}
+        }
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", False)
+        module.fail_json.assert_called()
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    "test-component-name"
+                ]
+            }}
+        }
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", False)
+        module.fail_json.assert_called()
+
+    def test_missing_component(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    {
+                        "name": "test-component-name-exist",
+                        "enabled": False,
+                    }
+                ]
+            }}
+        }
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", True)
+        module.fail_json.assert_not_called()
+        assert obj["spec"]["overrides"]["components"] == [
+            {
+                "name": "test-component-name-exist",
+                "enabled": False,
+            },
+            {
+                "name": "test-component-name",
+                "enabled": True
+            }]
+
+    def test_no_change_component(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    {
+                        "name": "test-component-name",
+                        "enabled": True,
+                    }
+                ]
+            }}
+        }
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", True)
+        module.fail_json.assert_not_called()
+        assert obj["spec"]["overrides"]["components"] == [{
+            "name": "test-component-name",
+            "enabled": True
+        }]
+
+    def test_update_component(self):
+        obj = {
+            "spec": {"overrides": {
+                "components": [
+                    {
+                        "name": "test-component-name",
+                        "enabled": False,
+                    }
+                ]
+            }}
+        }
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", True)
+        module.fail_json.assert_not_called()
+        assert obj["spec"]["overrides"]["components"] == [{
+            "name": "test-component-name",
+            "enabled": True
+        }]
+        module = MagicMock()
+        set_component_status(obj, module, "test-component-name", False)
+        module.fail_json.assert_not_called()
+        assert obj["spec"]["overrides"]["components"] == [{
+            "name": "test-component-name",
+            "enabled": False
+        }]


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>

Tests:
- [x] can enable/disable managed-serviceaccount in MCE
- [x] can enable/disable managed-serviceaccount in MCH
- [x] can enable/disable search in MCH
- [x] can enable/disable cluster-proxy in MCH